### PR TITLE
Remove CFP link from the app

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -14,7 +14,7 @@
                 <!-- <li><a href="agenda">Agenda</a></li> -->
                 <li><a class="text-xl" href="/speakers">Speakers</a></li>
                 <!-- <li><a href="sponsors">Sponsors</a></li> -->
-                <li><a class="text-xl" href="https://docs.google.com/forms/d/1XyoW2doQvHg51Vh29iEgE6Q6RTX8zbmxJfOg9zAZQmM/viewform?edit_requested=true">CFP</a></li>
+                <!-- <li><a class="text-xl" href="https://docs.google.com/forms/d/1XyoW2doQvHg51Vh29iEgE6Q6RTX8zbmxJfOg9zAZQmM/viewform?edit_requested=true">CFP</a></li> -->
                 <!-- <li><a href="about">About</a></li> -->
                 <li><a class="text-xl" href="/coc">CoC</a></li>
             </ul>
@@ -51,6 +51,4 @@ window.addEventListener('scroll', function() {
     }
   });
 </script>
-
-
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -71,10 +71,6 @@ export const NAVIGATION_LINKS: Array<INavigationLink> = [
   { title: "Speakers", href: "/speakers" },
   // {title: 'Sponsors', href: '/sponsors'},
   // {title: 'About', href: '/about'},
-  {
-    title: "CFP",
-    href: "https://docs.google.com/forms/d/1XyoW2doQvHg51Vh29iEgE6Q6RTX8zbmxJfOg9zAZQmM/viewform?edit_requested=true",
-  },
   { title: "CoC", href: "/coc" },
   // {title: 'Venue', href: '/venue'},
 ];


### PR DESCRIPTION
Removes the CFP link from the conference website as per the task requirements.
- **In `src/constants.ts`**: Removes the CFP entry from the `NAVIGATION_LINKS` array, ensuring it no longer appears in the site's navigation.
- **In `src/components/Header.astro`**: Deletes the CFP link from the header navigation menu, aligning the header with the updated navigation structure.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/this-is-learning/this-is-learning-conf-website?shareId=0336eee1-28f7-4038-9ef9-0e3a1cc07f6f).